### PR TITLE
Supporting -attach_window on non-windows platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ To run BletchMAME, run the installer (BletchMAME.msi on Windows) and BletchMAME 
 ## Version History
 
 - 2.7 (TBD)
+	- Supporting -attach_window on SDLMAME 0.232 and higher
+	- Omitting -attach_window when MAME identified as lacking support
 
 - 2.6 (2021-Mar-6)
 	- Added a number of MAMEUI-style builtin folders 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -188,7 +188,7 @@ private:
 	void PlaceInRecentFiles(const QString &tag, const QString &path);
 	info::machine getRunningMachine() const;
 	bool attachToMainWindow() const;
-	QWidget &attachWidget();
+	QString attachWidgetId() const;
 	void run(const info::machine &machine, std::unique_ptr<SessionBehavior> &&sessionBehavior);
 	QString preflightCheck() const;
 	QString GetFileDialogFilename(const QString &caption, Preferences::machine_path_type pathType, const QString &filter, QFileDialog::AcceptMode acceptMode);

--- a/src/mameversion.cpp
+++ b/src/mameversion.cpp
@@ -28,18 +28,6 @@ MameVersion::MameVersion(const QString &version)
 
 
 //-------------------------------------------------
-//  ctor
-//-------------------------------------------------
-
-MameVersion::MameVersion(int major, int minor, bool dirty)
-	: m_major(major)
-	, m_minor(minor)
-	, m_dirty(dirty)
-{
-}
-
-
-//-------------------------------------------------
 //  isAtLeast
 //-------------------------------------------------
 

--- a/src/mameversion.h
+++ b/src/mameversion.h
@@ -12,6 +12,12 @@
 #define MAMEVERSION_H
 
 #include <QString>
+#include <optional>
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
 
 // ======================> MameVersion
 
@@ -22,7 +28,12 @@ public:
 
 	// ctor
 	MameVersion(const QString &version);
-	MameVersion(int major, int minor, bool dirty);
+	constexpr MameVersion(int major, int minor, bool dirty)
+		: m_major(major)
+		, m_minor(minor)
+		, m_dirty(dirty)
+	{
+	}
 
 	// accessors
 	int major() const	{ return m_major; }
@@ -34,6 +45,9 @@ public:
 	MameVersion nextCleanVersion() const;
 	QString toString() const;
 
+	// MAME versions
+	struct Capabilities;
+
 private:
 	int	m_major;
 	int m_minor;
@@ -41,5 +55,31 @@ private:
 
 	static void parse(const QString &versionString, int &major, int &minor, bool &dirty);
 };
+
+
+
+// ======================> MameVersion::Capabilities
+
+struct MameVersion::Capabilities
+{
+	// -attach_window support
+#if defined(Q_OS_WIN32)
+	static constexpr std::optional<MameVersion> HAS_ATTACH_WINDOW = MameVersion(0, 213, false);
+	static constexpr std::optional<MameVersion> HAS_ATTACH_CHILD_WINDOW = MameVersion(0, 218, false);
+#elif defined(Q_OS_UNIX)
+	static constexpr std::optional<MameVersion> HAS_ATTACH_WINDOW = MameVersion(0, 232, false);
+	static constexpr std::optional<MameVersion> HAS_ATTACH_CHILD_WINDOW = MameVersion(0, 232, false);
+#else
+	static constexpr std::optional<MameVersion> HAS_ATTACH_WINDOW = std::nullopt;
+	static constexpr std::optional<MameVersion> HAS_ATTACH_CHILD_WINDOW = std::nullopt;
+#endif
+
+	// minimum MAME version
+	static constexpr MameVersion MINIMUM_SUPPORTED = MameVersion(0, 213, false);
+
+	// recording movies by specifying absolute paths was introduced in MAME 0.221
+	static constexpr MameVersion HAS_TOGGLE_MOVIE = MameVersion(0, 221, false);
+};
+
 
 #endif // MAMEVERSION_H

--- a/src/runmachinetask.cpp
+++ b/src/runmachinetask.cpp
@@ -26,6 +26,24 @@
 #define LOG_POST			0
 
 
+// MAME requires different arguments on different platforms
+#if defined(Q_OS_WIN32)
+
+// Win32 declarations
+#define KEYBOARD_PROVIDER	"dinput"
+#define MOUSE_PROVIDER		"dinput"
+#define LIGHTGUN_PROVIDER	"dinput"
+
+#else
+
+// Everything else
+#define KEYBOARD_PROVIDER	""
+#define MOUSE_PROVIDER		""
+#define LIGHTGUN_PROVIDER	""
+
+#endif
+
+
 //**************************************************************************
 //  VARIABLES
 //**************************************************************************
@@ -43,11 +61,11 @@ QEvent::Type ChatterEvent::s_eventId = (QEvent::Type) QEvent::registerEventType(
 //  ctor
 //-------------------------------------------------
 
-RunMachineTask::RunMachineTask(info::machine machine, QString &&software, std::map<QString, QString> &&slotOptions, QWidget &targetWindow)
+RunMachineTask::RunMachineTask(info::machine machine, QString &&software, std::map<QString, QString> &&slotOptions, QString &&attachWindowParameter)
     : m_machine(machine)
 	, m_software(std::move(software))
 	, m_slotOptions(std::move(slotOptions))
-    , m_attachWindowParameter(getAttachWindowParameter(targetWindow))
+    , m_attachWindowParameter(std::move(attachWindowParameter))
 	, m_chatterEnabled(false)
 	, m_startedWithHashPaths(false)
 {
@@ -85,46 +103,32 @@ QStringList RunMachineTask::getArguments(const Preferences &prefs) const
 		results.push_back(opt.second);
 	}
 
-	// and the rest of them
-	QStringList args =
-	{
-		"-rompath",
-		prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::ROMS),
-		"-samplepath",
-		prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::SAMPLES),
-		"-cfg_directory",
-		prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::CONFIG),
-		"-nvram_directory",
-		prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::NVRAM),
-		"-hashpath",
-		prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::HASH),
-		"-artpath",
-		prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::ARTWORK),
-		"-pluginspath",
-		prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::PLUGINS),
-		"-cheatpath",
-		prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::CHEATS),
-		"-window",
-#if HAS_DINPUT
-		"-keyboardprovider",
-		"dinput",
-		"-mouseprovider",
-		"dinput",
-		"-lightgunprovider",
-		"dinput",
-#endif // HAS_DINPUT
-#if HAS_ATTACH_WINDOW
-		"-attach_window",
-		m_attachWindowParameter,
-#endif // HAS_ATTACH_WINDOW
-		"-skip_gameinfo",
-		"-nomouse",
-		"-debug",
-		"-plugin",
-		WORKER_UI_PLUGIN_NAME
-	};
+	// variable arguments
+	if (strlen(KEYBOARD_PROVIDER) > 0)
+		results << "-keyboardprovider" << KEYBOARD_PROVIDER;
+	if (strlen(MOUSE_PROVIDER) > 0)
+		results << "-mouseprovider" << MOUSE_PROVIDER;
+	if (strlen(LIGHTGUN_PROVIDER) > 0)
+		results << "-lightgunprovider" << LIGHTGUN_PROVIDER;
+	if (!m_attachWindowParameter.isEmpty())
+		results << "-attach_window" << m_attachWindowParameter;
 
-	results.append(args);
+
+	// and the rest of them
+	results << "-rompath"			<< prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::ROMS);
+	results << "-samplepath"		<< prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::SAMPLES);
+	results << "-cfg_directory"		<< prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::CONFIG);
+	results << "-nvram_directory"	<< prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::NVRAM);
+	results << "-hashpath"			<< prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::HASH);
+	results << "-artpath"			<< prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::ARTWORK);
+	results << "-pluginspath"		<< prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::PLUGINS);
+	results << "-cheatpath"			<< prefs.GetGlobalPathWithSubstitutions(Preferences::global_path_type::CHEATS);
+	results << "-plugin"			<< WORKER_UI_PLUGIN_NAME;
+	results << "-window";
+	results << "-skip_gameinfo";
+	results << "-nomouse";
+	results << "-debug";
+
 	return results;
 }
 
@@ -222,19 +226,6 @@ QString RunMachineTask::buildCommand(const std::vector<QString> &args)
 	}
 	command += "\r\n";
 	return command;
-}
-
-
-//-------------------------------------------------
-//  getAttachWindowParameter - determine the
-//	parameter to pass to '-attach_window'
-//-------------------------------------------------
-
-QString RunMachineTask::getAttachWindowParameter(const QWidget &targetWindow)
-{
-	// the documentation for QWidget::WId() says that this value can change any
-	// time; this is probably not true on Windows (where this returns the HWND)
-	return QString::number(targetWindow.winId());
 }
 
 

--- a/src/runmachinetask.h
+++ b/src/runmachinetask.h
@@ -27,21 +27,6 @@
 // the name of the worker_ui plugin
 #define WORKER_UI_PLUGIN_NAME	"worker_ui"
 
-// MAME requires different arguments on different platforms
-#if defined(Q_OS_WIN32)
-
-// Win32 declarations
-#define HAS_ATTACH_WINDOW	1
-#define HAS_DINPUT			1
-
-#else
-
-// Everything else
-#define HAS_ATTACH_WINDOW	0
-#define HAS_DINPUT			0
-
-#endif
-
 
 //**************************************************************************
 //  TYPE DEFINITIONS
@@ -106,7 +91,7 @@ class RunMachineTask : public Task
 public:
 	class Test;
 
-	RunMachineTask(info::machine machine, QString &&software, std::map<QString, QString> &&slotOptions, QWidget &targetWindow);
+	RunMachineTask(info::machine machine, QString &&software, std::map<QString, QString> &&slotOptions, QString &&attachWindowParameter);
 
 	void issue(const std::vector<QString> &args);
 	void issueFullCommandLine(QString &&full_command);
@@ -145,7 +130,6 @@ private:
 	mutable bool					m_startedWithHashPaths;
 
 	static QString buildCommand(const std::vector<QString> &args);
-	static QString getAttachWindowParameter(const QWidget &targetWindow);
 
 	void internalPost(Message::type type, QString &&command, emu_error status = emu_error::INVALID);
 	static MameWorkerController::Response receiveResponseAndHandleUpdates(MameWorkerController &controller, QObject &handler);


### PR DESCRIPTION
1. Supporting -attach_window on SDLMAME 0.232 and higher
2. Omitting -attach_window when MAME identified as lacking support