### PR TITLE
Various cmake improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ CMakeFiles
 cmake_install.cmake
 CTestTestfile.cmake
 Makefile
+install_manifest.txt
 *.dir
 *_autogen
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ MESSAGE(STATUS "buildversion.gen.cpp UNAVAILABLE")
 add_definitions(-DHAS_BUILDVERSION_GEN_CPP=0)
 endif()
 
+# Define installation directories
+include(GNUInstallDirs)
 
 #############################################################################
 # BletchMAME core (library shared by executable and tests)                  #
@@ -163,6 +165,7 @@ target_link_libraries(BletchMAME_core PRIVATE Qt5::Widgets QuaZip)
 add_executable(BletchMAME WIN32 src/main.cpp src/resources.qrc)
 target_include_directories(BletchMAME PRIVATE src lib)
 target_link_libraries(BletchMAME PRIVATE BletchMAME_core Qt5::Widgets ${EXPAT_LIBRARIES} ${ZLIB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+install(TARGETS BletchMAME RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 
 #############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,14 @@ include_directories(${ZLIB_INCLUDE_DIRS})
 find_package(Qt5 COMPONENTS Widgets LinguistTools REQUIRED)
 find_package(Qt5Test REQUIRED)
 
+# QuaZip
+find_package(QuaZip5)
+if (NOT QUAZIP_FOUND)
+set(QUAZIP_INCLUDE_DIRS lib/quazip)
+set(QUAZIP_LIBRARIES QuaZip)
+endif()
+include_directories(${QUAZIP_INCLUDE_DIRS})
+
 # Yes, we're unit testing
 enable_testing(true)
 
@@ -155,7 +163,7 @@ add_library(BletchMAME_core
 	${TS_FILES}
 )
 target_include_directories(BletchMAME_core PRIVATE src lib)
-target_link_libraries(BletchMAME_core PRIVATE Qt5::Widgets QuaZip)
+target_link_libraries(BletchMAME_core PRIVATE Qt5::Widgets ${QUAZIP_LIBRARIES})
 
 
 #############################################################################
@@ -207,6 +215,7 @@ target_link_libraries(BletchMAME_tests PRIVATE BletchMAME_core Qt5::Widgets Qt5:
 # QuaZib																	#
 #############################################################################
 
+if (NOT QUAZIP_FOUND)
 add_library(QuaZip
 	lib/quazip/ioapi.h
 	lib/quazip/JlCompress.cpp
@@ -241,7 +250,7 @@ add_library(QuaZip
 target_include_directories(QuaZip PRIVATE lib/quazip)
 target_link_libraries(QuaZip PRIVATE Qt5::Widgets ${ZLIB_LIBRARIES})
 add_definitions(-DQUAZIP_STATIC -DNOCRYPT)
-
+endif()
 
 #############################################################################
 # Translations                                                              #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,10 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+option(USE_SHARED_LIBS "Use shared libraries" OFF)
+if (NOT USE_SHARED_LIBS)
 SET(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+endif()
 
 # Threads
 find_package( Threads )

--- a/src/iconloader.cpp
+++ b/src/iconloader.cpp
@@ -8,8 +8,8 @@
 
 #include "iconloader.h"
 #include "prefs.h"
-#include "quazip/quazip.h"
-#include "quazip/quazipfile.h"
+#include <quazip.h>
+#include <quazipfile.h>
 
 
 //**************************************************************************


### PR DESCRIPTION
A number of cmake improvements to make the project easier to build on Linux:
- add a variable to use system shared libraries instead of static (disabled by default)
- add a build rule to install the binary
- use the quazip system library instead of the bundled one if it's available