### PR TITLE
Print output when MAME fails to start

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -111,6 +111,7 @@ void MameClient::taskThreadProc()
 	if (!processId || !m_process->waitForStarted() || !m_process->waitForReadyRead())
 	{
 		// TODO - better error handling, especially when we're not pointed at the proper executable
+		qInfo() << "Failed to run MAME!\nstdout=" << m_process->readAllStandardOutput() << "\nstderr=" << m_process->readAllStandardError();
 		throw false;
 	}
 


### PR DESCRIPTION
Right now if MAME fails to start for whatever reason there is no feedback. Print the output of the command on console to help troubleshooting at bit.