### PR TITLE
Allow picking files for icons path

### DIFF
--- a/src/dialogs/paths.cpp
+++ b/src/dialogs/paths.cpp
@@ -344,7 +344,6 @@ bool PathsDialog::isDirPathType(Preferences::global_path_type type)
 		|| type == Preferences::global_path_type::NVRAM
 		|| type == Preferences::global_path_type::HASH
 		|| type == Preferences::global_path_type::ARTWORK
-		|| type == Preferences::global_path_type::ICONS
 		|| type == Preferences::global_path_type::PLUGINS
 		|| type == Preferences::global_path_type::PROFILES
 		|| type == Preferences::global_path_type::CHEATS


### PR DESCRIPTION
Icons path is supposed to point to a zipfile, so allow picking a file in the file picker. This is consistent with `isFilePathType`. 