### PR TITLE
Optimized audit status updates on the machine list

### DIFF
--- a/src/info.h
+++ b/src/info.h
@@ -689,7 +689,6 @@ namespace info
 		bool load(QIODevice &input, const QString &expected_version = "");
 		bool load(const QByteArray &byteArray, const QString &expected_version = "");
 		void reset();
-		std::optional<int> find_machine_index(const QString &machine_name) const;
 		std::optional<machine> find_machine(const QString &machine_name) const;
 		const QString &version() const			{ return *m_version; }
 		void addOnChangedHandler(std::function<void()> &&onChanged);
@@ -778,6 +777,7 @@ namespace info
 
 		// private functions
 		void onChanged();
+		std::optional<int> find_machine_index(const QString &machine_name) const;
 		static std::optional<std::uint32_t> tryEncodeSmallStringChar(char8_t ch);
 		static std::optional<std::uint32_t> tryEncodeAsSmallString(std::u8string_view s);
 		static std::optional<std::array<char8_t, 6>> tryDecodeAsSmallString(std::uint32_t value);

--- a/src/machinelistitemmodel.cpp
+++ b/src/machinelistitemmodel.cpp
@@ -82,15 +82,10 @@ bool MachineListItemModel::isMachinePresent(const info::machine &machine) const
 void MachineListItemModel::auditStatusChanged(const MachineAuditIdentifier &identifier)
 {
 	ProfilerScope prof(CURRENT_FUNCTION);
-	std::optional<int> machineIndex = m_infoDb.find_machine_index(identifier.machineName());
-	if (machineIndex)
-	{
-		auto iter = m_reverseIndexes.find(machineIndex.value());
-		if (iter != m_reverseIndexes.end())
-			iconsChanged(iter->second, iter->second);
-	}
+	auto iter = m_reverseIndexes.find(identifier.machineName());
+	if (iter != m_reverseIndexes.end())
+		iconsChanged(iter->second, iter->second);
 }
-
 
 
 //-------------------------------------------------
@@ -147,7 +142,7 @@ void MachineListItemModel::populateIndexes()
 		// we need to apply a filter (if we have one)
 		if (isMachinePresent(machine))
 		{
-			m_reverseIndexes.insert({ i, util::safe_static_cast<int>(m_indexes.size()) });
+			m_reverseIndexes.insert({ std::reference_wrapper<const QString>(machine.name()), util::safe_static_cast<int>(m_indexes.size()) });
 			m_indexes.push_back(i);
 		}
 	}

--- a/src/machinelistitemmodel.h
+++ b/src/machinelistitemmodel.h
@@ -44,7 +44,7 @@ public:
 	void allAuditStatusesChanged();
 
 	// virtuals
-	virtual QModelIndex index(int row, int column, const QModelIndex &parent) const override;
+	virtual QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
 	virtual QModelIndex parent(const QModelIndex &child) const override;
 	virtual int rowCount(const QModelIndex &parent) const override;
 	virtual int columnCount(const QModelIndex &parent) const override;

--- a/src/machinelistitemmodel.h
+++ b/src/machinelistitemmodel.h
@@ -11,6 +11,7 @@
 
 #include "auditablelistitemmodel.h"
 #include "info.h"
+#include "utility.h"
 
 
 //**************************************************************************
@@ -54,11 +55,13 @@ public:
 	virtual bool isAuditIdentifierPresent(const AuditIdentifier &identifier) const override;
 
 private:
+	typedef std::unordered_map<std::reference_wrapper<const QString>, int> ReverseIndexMap;
+
 	info::database &									m_infoDb;
 	IconLoader *										m_iconLoader;
 	std::function<bool(const info::machine &machine)>	m_machineFilter;
 	std::vector<int>									m_indexes;
-	std::unordered_map<int, int>						m_reverseIndexes;
+	ReverseIndexMap										m_reverseIndexes;
 	std::function<void(info::machine)>					m_machineIconAccessedCallback;
 
 	void iconsChanged(int startIndex, int endIndex);

--- a/src/tests/info_test.cpp
+++ b/src/tests/info_test.cpp
@@ -29,7 +29,6 @@ namespace
 		void loadExpectedVersion_coco()		{ loadExpectedVersion(":/resources/listxml_coco.xml", "0.229 (mame0229)"); }
 		void loadExpectedVersion_alienar()	{ loadExpectedVersion(":/resources/listxml_alienar.xml", "0.229 (mame0229)"); }
 		void badMachineLookup();
-		void badMachineIndexLookup();
 		void viewIterators();
 		void loadGarbage_0_0()				{ loadGarbage(0, 0); }
 		void loadGarbage_0_1000()			{ loadGarbage(0, 1000); }
@@ -186,21 +185,6 @@ void Test::badMachineLookup()
 	QVERIFY(db.machines().size() > 0);
 
 	std::optional<info::machine> result = db.find_machine("this_is_an_invalid_machine");
-	QVERIFY(!result.has_value());
-}
-
-
-//-------------------------------------------------
-//	badMachineIndexLookup
-//-------------------------------------------------
-
-void Test::badMachineIndexLookup()
-{
-	info::database db;
-	QVERIFY(db.load(buildInfoDatabase()));
-	QVERIFY(db.machines().size() > 0);
-
-	std::optional<int> result = db.find_machine_index("this_is_an_invalid_machine");
 	QVERIFY(!result.has_value());
 }
 
@@ -499,9 +483,6 @@ void Test::scrutinize_alienar()
 		QVERIFY(rom.bios().isEmpty());
 		QVERIFY(rom.merge().isEmpty());
 	}
-
-	std::optional<int> machineIndex = db.find_machine_index("alienar");
-	QVERIFY(machineIndex == 0);
 }
 
 
@@ -521,9 +502,6 @@ void Test::scrutinize_coco()
 	QVERIFY(!machine->clone_of().has_value());
 	QVERIFY(!machine->rom_of().has_value());
 	QVERIFY(machine->sound_channels() == 1);
-
-	std::optional<int> machineIndex = db.find_machine_index("coco");
-	QVERIFY(machineIndex == 9);
 }
 
 
@@ -545,9 +523,6 @@ void Test::scrutinize_coco2b()
 	QVERIFY(machine->rom_of().has_value());
 	QVERIFY(machine->rom_of()->name() == "coco");
 	QVERIFY(machine->sound_channels() == 3);
-
-	std::optional<int> machineIndex = db.find_machine_index("coco2b");
-	QVERIFY(machineIndex == 12);
 }
 
 

--- a/src/utility.h
+++ b/src/utility.h
@@ -79,6 +79,15 @@ namespace std
 			return !strcmp(s1, s2);
 		}
 	};
+
+	template<> class hash<std::reference_wrapper<const QString>>
+	{
+	public:
+		std::size_t operator()(const std::reference_wrapper<const QString> &s) const
+		{
+			return std::hash<QString>()(s);
+		}
+	};
 }
 
 


### PR DESCRIPTION
Optimized MachineListItemModel::auditStatusChanged()
- Changed MachineListItemModel::m_reverseIndexes to be a direct map of machine names to statuses
- info::database::find_machine_index() no longer needs to be public
Also added unit tests