### PR TITLE
Fixed a problem (thread safety when reading from MAME) that could cause random crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ To run BletchMAME, run the installer (BletchMAME.msi on Windows) and BletchMAME 
 ## Version History
 
 - 2.12 (TBD)
+	- Fixed a problem (thread safety when reading from MAME) that could cause random crashes
 	- Placing the BletchMAME version and (when running) the MAME version on the title bar
 	- Cosmetic changes to the "About..." dialog to make it appear cleaner
 

--- a/src/runmachinetask.cpp
+++ b/src/runmachinetask.cpp
@@ -147,7 +147,7 @@ void RunMachineTask::abort()
 	issue({ "exit" });
 
 	// but kill anyways
-	emuPocess().kill();
+	killActiveEmuProcess();
 
 	internalPost(Message::type::TERMINATED, "", EmuError::Killed);
 }

--- a/src/taskdispatcher.h
+++ b/src/taskdispatcher.h
@@ -94,8 +94,10 @@ public:
 private:
 	struct ActiveTask
 	{
-		Task::ptr	m_task;
-		std::thread	m_thread;
+		Task::ptr					m_task;
+		std::unique_ptr<QThread>	m_thread;
+
+		void join();
 	};
 
 	QObject &					m_eventHandler;


### PR DESCRIPTION
The issue was due to contention between reading from QProcess while the main thread (where the QProcess was hosted) was processing events.  The fix was to change the QProcess to reside entirely in the task thread.