### PR TITLE
Use the correct path separator everywhere

### DIFF
--- a/src/importmameinijob.cpp
+++ b/src/importmameinijob.cpp
@@ -10,6 +10,11 @@
 #include "importmameinijob.h"
 #include "iniparser.h"
 
+#ifdef Q_OS_WIN32
+#define PATH_LIST_SEPARATOR     ";"
+#else
+#define PATH_LIST_SEPARATOR     ":"
+#endif
 
 //**************************************************************************
 //  TYPES
@@ -355,7 +360,7 @@ void ImportMameIniJob::GlobalPathEntry::doSupplement()
 {
 	QStringList paths = m_prefs.getSplitPaths(m_pathType);
 	paths << m_path;
-	m_prefs.setGlobalPath(m_pathType, paths.join(";"));
+	m_prefs.setGlobalPath(m_pathType, paths.join(PATH_LIST_SEPARATOR));
 }
 
 

--- a/src/prefs.cpp
+++ b/src/prefs.cpp
@@ -89,6 +89,12 @@ static const util::enum_parser_bidirectional<Preferences::AuditingState> s_audit
 //  IMPLEMENTATION
 //**************************************************************************
 
+#ifdef Q_OS_WIN32
+#define PATH_LIST_SEPARATOR     ";"
+#else
+#define PATH_LIST_SEPARATOR     ":"
+#endif
+
 //-------------------------------------------------
 //  isValidDimension
 //-------------------------------------------------
@@ -391,7 +397,7 @@ QStringList Preferences::getSplitPaths(global_path_type type) const
 	const QString &pathsString = getGlobalPath(type);
 	if (!pathsString.isEmpty())
 	{
-		paths = pathsString.split(';');
+		paths = pathsString.split(PATH_LIST_SEPARATOR);
 		for (QString &path : paths)
 		{
 			// apply variable substituions
@@ -1333,7 +1339,7 @@ Preferences::GlobalUiInfo::GlobalUiInfo()
 Preferences::GlobalPathsInfo::GlobalPathsInfo(const std::optional<QDir> &configDirectory)
 {
 	// set up default paths - some of these require a config directory
-	m_paths[(size_t)global_path_type::PLUGINS]		= "$(BLETCHMAMEPATH)/plugins/;$(MAMEPATH)/plugins/";
+	m_paths[(size_t)global_path_type::PLUGINS]		= "$(BLETCHMAMEPATH)/plugins/" PATH_LIST_SEPARATOR "$(MAMEPATH)/plugins/";
 	m_paths[(size_t)global_path_type::HASH]			= "$(MAMEPATH)/hash/";
 	if (configDirectory)
 	{


### PR DESCRIPTION
Ensure we're always using the correct path separator for the running platform. `PATH_LIST_SEPARATOR` should probably be refactored into some common include but I wasn't sure which one to use, so I just duplicated it for now.