### PR TITLE
Fix include path when doing an out-of-tree build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ add_library(BletchMAME_core
 	src/dialogs/switches.h
 	${TS_FILES}
 )
-target_include_directories(BletchMAME_core PRIVATE src lib ${CMAKE_CURRENT_BINARY_DIR}/include)
+target_include_directories(BletchMAME_core PRIVATE src lib ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(BletchMAME_core PRIVATE Qt6::Widgets ${QUAZIP_LIBRARIES} Qt6::Core5Compat ${ZLIB_LIBRARIES})
 
 
@@ -263,7 +263,7 @@ target_link_libraries(BletchMAME_core PRIVATE Qt6::Widgets ${QUAZIP_LIBRARIES} Q
 #############################################################################
 
 add_executable(BletchMAME WIN32 src/main.cpp src/resources.qrc src/winresources.rc)
-target_include_directories(BletchMAME PRIVATE src lib ${CMAKE_CURRENT_BINARY_DIR}/include)
+target_include_directories(BletchMAME PRIVATE src lib ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(BletchMAME PRIVATE BletchMAME_core Qt6::Widgets ${QUAZIP_LIBRARIES} Qt6::Core5Compat ${EXPAT_LIBRARIES} ${ZLIB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 install(TARGETS BletchMAME RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 

--- a/scripts/bletchmame_build_msvc2019.sh
+++ b/scripts/bletchmame_build_msvc2019.sh
@@ -78,8 +78,8 @@ cmake -S. -B${BLETCHMAME_BUILD_DIR}										\
 	-DCMAKE_INCLUDE_PATH=$DEPS_INSTALL_DIR/include
 
 # generate version.gen.h
-mkdir -p ${BLETCHMAME_BUILD_DIR}/include
-git describe --tags | perl scripts/process_version.pl --versionhdr > ${BLETCHMAME_BUILD_DIR}/include/version.gen.h
+mkdir -p ${BLETCHMAME_DIR}/include
+git describe --tags | perl scripts/process_version.pl --versionhdr > ${BLETCHMAME_DIR}/include/version.gen.h
 
 # and build!
 cmake --build ${BLETCHMAME_BUILD_DIR} --parallel --config ${CONFIG}

--- a/scripts/bletchmame_build_msys2.sh
+++ b/scripts/bletchmame_build_msys2.sh
@@ -51,8 +51,8 @@ cmake -S. -B${BLETCHMAME_BUILD_DIR}												\
 	-DQuaZip-Qt6_DIR=${DEPS_INSTALL_DIR}/lib/cmake/QuaZip-Qt6-1.1
 
 # generate version.gen.h
-mkdir -p ${BLETCHMAME_BUILD_DIR}/include
-git describe --tags | perl scripts/process_version.pl --versionhdr > ${BLETCHMAME_BUILD_DIR}/include/version.gen.h
+mkdir -p ${BLETCHMAME_DIR}/include
+git describe --tags | perl scripts/process_version.pl --versionhdr > ${BLETCHMAME_DIR}/include/version.gen.h
 
 # and build!
 cmake --build ${BLETCHMAME_BUILD_DIR} --parallel


### PR DESCRIPTION
cmake allows one to do an out-of-tree build, where the object files are put in a separate directory. In that case, `CMAKE_CURRENT_BINARY_DIR` won't be pointing to the source, which will cause a build failure if `-DHAS_VERSION_GEN_H=1` is being used as `version.gen.h` won't be found. Fix this by using `CMAKE_SOURCE_DIR` instead.