### PR TITLE
Separating out "details" aspects of status::image, so they don't need to be as aggressively updated

### DIFF
--- a/src/dialogs/confdev.cpp
+++ b/src/dialogs/confdev.cpp
@@ -265,7 +265,7 @@ void ConfigurableDevicesDialog::updateImages()
     auto iter = std::find_if(
         images.cbegin(),
         images.cend(),
-        [](const status::image &image) { return image.m_must_be_loaded && image.m_file_name.isEmpty(); });
+        [](const status::image &image) { return image.m_details && image.m_details->m_must_be_loaded && image.m_file_name.isEmpty(); });
     bool anyMandatoryImagesMissing = iter != images.cend();
 
     // set the ok button enabled property

--- a/src/dialogs/confdevmodel.cpp
+++ b/src/dialogs/confdevmodel.cpp
@@ -150,13 +150,16 @@ public:
 
 	void setImage(const status::image &image)
 	{
-		m_image.emplace();
-		m_image->m_instanceName	= image.m_instance_name;
-		m_image->m_fileName		= image.m_file_name;
-		m_image->m_isReadable	= image.m_is_readable;
-		m_image->m_isWriteable	= image.m_is_writeable;
-		m_image->m_isCreatable	= image.m_is_creatable;
-		m_image->m_mustBeLoaded	= image.m_must_be_loaded;
+		if (image.m_details)
+		{
+			m_image.emplace();
+			m_image->m_fileName		= image.m_file_name;
+			m_image->m_instanceName	= image.m_details->m_instance_name;
+			m_image->m_isReadable	= image.m_details->m_is_readable;
+			m_image->m_isWriteable	= image.m_details->m_is_writeable;
+			m_image->m_isCreatable	= image.m_details->m_is_creatable;
+			m_image->m_mustBeLoaded	= image.m_details->m_must_be_loaded;
+		}
 	}
 
 private:

--- a/src/imagemenu.cpp
+++ b/src/imagemenu.cpp
@@ -41,10 +41,10 @@ static std::vector<QString> getExtensions(IImageMenuHost &host, const QString &t
 
 	// first try getting the result from the image format
 	const status::image *image = host.getRunningState().find_image(tag);
-	if (image && image->m_formats.has_value())
+	if (image && image->m_details)
 	{
 		// we did find it in the image formats
-		for (const status::image_format &format : *image->m_formats)
+		for (const status::image_format &format : image->m_details->m_formats)
 		{
 			for (const QString &ext : format.m_extensions)
 			{
@@ -226,7 +226,7 @@ void appendImageMenuItems(IImageMenuHost &host, QMenu &popupMenu, const QString 
 		if (!popupMenu.isEmpty())
 			popupMenu.addSeparator();
 
-		if (image->m_is_creatable)
+		if (image->m_details && image->m_details->m_is_creatable)
 			popupMenu.addAction("Create Image...", [&host, &popupMenu, &tag]() { createImage(host, &popupMenu, tag); });
 
 		// load image

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1823,7 +1823,8 @@ void MainWindow::run(const info::machine &machine, std::unique_ptr<SessionBehavi
 	// do we have any images that require images?
 	auto iter = std::find_if(m_state->images().get().cbegin(), m_state->images().get().cend(), [&behaviorImages](const status::image &image)
 	{
-		return image.m_must_be_loaded										// is this an image that must be loaded?
+		return image.m_details
+			&& image.m_details->m_must_be_loaded							// is this an image that must be loaded?
 			&& image.m_file_name.isEmpty()									// and the filename is empty?
 			&& behaviorImages.find(image.m_tag) == behaviorImages.end();	// and it wasn't specified as a "behavior image" (in which case we need to wait)?
 	});

--- a/src/status.h
+++ b/src/status.h
@@ -60,6 +60,26 @@ namespace status
 		bool operator==(const image_format &) const = default;
 	};
 
+
+	// ======================> image_details
+	struct image_details
+	{
+		image_details() = default;
+		image_details(const image_details &) = delete;
+		image_details(image_details &&) = default;
+
+		QString						m_instance_name;
+		bool						m_is_readable;
+		bool						m_is_writeable;
+		bool						m_is_creatable;
+		bool						m_must_be_loaded;
+		std::vector<image_format>	m_formats;
+
+		image_details &operator=(image_details &&) = default;
+		bool operator==(const image_details &) const = default;
+	};
+
+
 	// ======================> image
 	struct image
 	{
@@ -67,18 +87,12 @@ namespace status
 		image(const image &) = delete;
 		image(image &&) = default;
 
-		QString				m_tag;
-		QString				m_instance_name;
-		bool				m_is_readable;
-		bool				m_is_writeable;
-		bool				m_is_creatable;
-		bool				m_must_be_loaded;
-		QString				m_file_name;
-		QString				m_display;
-		std::optional<std::vector<image_format>>	m_formats;
+		QString							m_tag;
+		QString							m_file_name;
+		std::shared_ptr<image_details>	m_details;
 
 		image &operator=(image &&) = default;
-		bool operator==(const image &) const = default;
+		bool operator==(const status::image &that) const;
 	};
 
 


### PR DESCRIPTION
Also pruned out status::image::m_display; we no longer use it