### PR TITLE
Fixed a bug that could cause image dropdowns to not properly display software list part names

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ To run BletchMAME, run the installer (BletchMAME.msi on Windows) and BletchMAME 
 
 ## Version History
 
+- 2.15 (TBD)
+	- Fixed a bug that could cause image dropdowns to not properly display software list part names
+
 - 2.14 (2022-Mar-26)
 	- In addition to the menu bar, ScrLk will now also toggle the visibility of the status bar
 	- Created a nicer status bar display for cassette status

--- a/src/devstatusdisplay.cpp
+++ b/src/devstatusdisplay.cpp
@@ -190,7 +190,7 @@ QString DevicesStatusDisplay::imageDisplayText(const status::image &image) const
 {
 	QString imageFileName = prettifyImageFileName(
 		m_host.getRunningMachine(),
-		m_host.getSoftwareListCollection(),
+		m_host.getRunningSoftwareListCollection(),
 		image.m_tag,
 		image.m_file_name,
 		false);

--- a/src/imagemenu.cpp
+++ b/src/imagemenu.cpp
@@ -219,8 +219,9 @@ void appendImageMenuItems(IImageMenuHost &host, QMenu &popupMenu, const QString 
 	const status::image *image = host.getRunningState().find_image(tag);
 	if (image)
 	{
+		// get critical information
 		info::machine machine = host.getRunningMachine();
-		const software_list_collection &softwareListCollection = host.getSoftwareListCollection();
+		const software_list_collection &softwareListCollection = host.getRunningSoftwareListCollection();
 
 		// add a separator if necessary
 		if (!popupMenu.isEmpty())

--- a/src/imagemenu.h
+++ b/src/imagemenu.h
@@ -37,7 +37,7 @@ class IImageMenuHost
 public:
 	virtual Preferences &getPreferences() = 0;
 	virtual info::machine getRunningMachine() const = 0;
-	virtual const software_list_collection &getSoftwareListCollection() = 0;
+	virtual const software_list_collection &getRunningSoftwareListCollection() const = 0;
 	virtual status::state &getRunningState() = 0;
 	virtual void createImage(const QString &tag, QString &&path) = 0;
 	virtual void loadImage(const QString &tag, QString &&path) = 0;

--- a/src/mainpanel.cpp
+++ b/src/mainpanel.cpp
@@ -807,7 +807,7 @@ void MainPanel::updateSoftwareList()
 		const info::machine machine = machineFromModelIndex(selection[0]);
 
 		// get the software list collection
-		software_list_collection &softwareListCollection = m_host.getSoftwareListCollection();
+		software_list_collection &softwareListCollection = m_host.getAuditSoftwareListCollection();
 
 		// load the software
 		m_currentSoftwareList = machine.name();

--- a/src/mainpanel.h
+++ b/src/mainpanel.h
@@ -49,7 +49,7 @@ public:
 	virtual void auditIfAppropriate(const info::machine &machine) = 0;
 	virtual void auditIfAppropriate(const software_list::software &software) = 0;
 	virtual void auditDialogStarted(AuditDialog &auditDialog, std::shared_ptr<AuditTask> &&auditTask) = 0;
-	virtual software_list_collection &getSoftwareListCollection() = 0;
+	virtual software_list_collection &getAuditSoftwareListCollection() = 0;
 	virtual void updateAuditTimer() = 0;
 };
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -167,7 +167,7 @@ private:
 	info::database						m_info_db;
 
 	// software lists
-	software_list_collection			m_softwareListCollection;
+	std::optional<software_list_collection>	m_runningSoftwareListCollection;
 
 	// status of running emulation
 	std::unique_ptr<SessionBehavior>	m_sessionBehavior;
@@ -175,6 +175,7 @@ private:
 
 	// auditing
 	AuditQueue							m_auditQueue;
+	software_list_collection			m_auditSoftwareListCollection;
 	QTimer *							m_auditTimer;
 	unsigned int						m_maximumConcurrentAuditTasks;
 	AuditCursor							m_auditCursor;
@@ -233,7 +234,7 @@ private:
 	virtual void run(const info::machine &machine, std::unique_ptr<SessionBehavior> &&sessionBehavior) override final;
 	virtual info::machine getRunningMachine() const override final;
 	virtual Preferences &getPreferences() override final;
-	virtual software_list_collection &getSoftwareListCollection() override final;
+	virtual const software_list_collection &getRunningSoftwareListCollection() const override final;
 	virtual status::state &getRunningState() override final;
 	virtual void createImage(const QString &tag, QString &&path) override final;
 	virtual void loadImage(const QString &tag, QString &&path) override final;
@@ -266,6 +267,7 @@ private:
 	bool canAutomaticallyAudit() const;
 	virtual void updateAuditTimer() override final;
 	virtual void auditDialogStarted(AuditDialog &auditDialog, std::shared_ptr<AuditTask> &&auditTask) override final;
+	virtual software_list_collection &getAuditSoftwareListCollection() override final;
 	void auditTimerProc();
 	void dispatchAuditTasks();
 	void reportAuditResults(const std::vector<AuditResult> &results);


### PR DESCRIPTION
This necessitated a cleaner separation between the software_list_collection used for auditing and at runtime