### PR TITLE
Added some (limited) range checking to info DB views

### DIFF
--- a/src/bindata.h
+++ b/src/bindata.h
@@ -142,6 +142,8 @@ namespace bindata
 
 			TPublic operator*() const
 			{
+				if (!m_db)
+					throw std::out_of_range("bindata::view::iterator::operator*");
 				return TPublic(*m_db, *m_spanIter);
 			}
 				

--- a/src/bindata.h
+++ b/src/bindata.h
@@ -104,7 +104,9 @@ namespace bindata
 
 		TPublic operator[](std::size_t position) const
 		{
-			return *(begin() + position);
+			if (position >= size())
+				throw std::out_of_range("bindata::view::operator[]");
+			return begin()[position];
 		}
 
 		size_t size() const { return m_span.size(); }

--- a/src/tests/info_test.cpp
+++ b/src/tests/info_test.cpp
@@ -34,6 +34,8 @@ namespace
 		void badMachineLookup();
 		void viewIterators();
 		void viewIndexOutOfRange();
+		void viewIteratorDerefOutOfRange();
+		void viewIteratorDerefAndAddOutOfRange();
 		void loadGarbage_0_0()				{ loadGarbage(0, 0); }
 		void loadGarbage_0_1000()			{ loadGarbage(0, 1000); }
 		void loadGarbage_1000_0()			{ loadGarbage(1000, 0); }
@@ -318,6 +320,61 @@ void Test::viewIndexOutOfRange()
 		}
 		QVERIFY(caughtOutOfRange);
 	}
+}
+
+
+//-------------------------------------------------
+//  viewIteratorDerefOutOfRange
+//-------------------------------------------------
+
+void Test::viewIteratorDerefOutOfRange()
+{
+	// there is probably a better way to get the type of a view iterator
+	info::database db;
+	QVERIFY(db.load(buildInfoDatabase()));
+	auto originalIter = db.machines().begin();
+	(void)originalIter;
+
+	// ensure that a deference of a default instantiated iterator throws an exception
+	decltype(originalIter) iter;
+	bool caughtOutOfRange = false;
+	try
+	{
+		(void) *iter;
+	}
+	catch (const std::out_of_range &)
+	{
+		caughtOutOfRange = true;
+	}
+	QVERIFY(caughtOutOfRange);
+}
+
+
+//-------------------------------------------------
+//  viewIteratorDerefAndAddOutOfRange
+//-------------------------------------------------
+
+void Test::viewIteratorDerefAndAddOutOfRange()
+{
+	// there is probably a better way to get the type of a view iterator
+	info::database db;
+	QVERIFY(db.load(buildInfoDatabase()));
+	auto originalIter = db.machines().begin();
+	(void)originalIter;
+
+	// ensure that a deference of an offsetted default instantiated iterator throws an exception
+	decltype(originalIter) iter1;
+	decltype(originalIter) iter2 = iter1 + 42;
+	bool caughtOutOfRange = false;
+	try
+	{
+		(void)*iter2;
+	}
+	catch (const std::out_of_range &)
+	{
+		caughtOutOfRange = true;
+	}
+	QVERIFY(caughtOutOfRange);
 }
 
 

--- a/src/tests/info_test.cpp
+++ b/src/tests/info_test.cpp
@@ -35,7 +35,6 @@ namespace
 		void viewIterators();
 		void viewIndexOutOfRange();
 		void viewIteratorDerefOutOfRange();
-		void viewIteratorDerefAndAddOutOfRange();
 		void loadGarbage_0_0()				{ loadGarbage(0, 0); }
 		void loadGarbage_0_1000()			{ loadGarbage(0, 1000); }
 		void loadGarbage_1000_0()			{ loadGarbage(1000, 0); }
@@ -341,34 +340,6 @@ void Test::viewIteratorDerefOutOfRange()
 	try
 	{
 		(void) *iter;
-	}
-	catch (const std::out_of_range &)
-	{
-		caughtOutOfRange = true;
-	}
-	QVERIFY(caughtOutOfRange);
-}
-
-
-//-------------------------------------------------
-//  viewIteratorDerefAndAddOutOfRange
-//-------------------------------------------------
-
-void Test::viewIteratorDerefAndAddOutOfRange()
-{
-	// there is probably a better way to get the type of a view iterator
-	info::database db;
-	QVERIFY(db.load(buildInfoDatabase()));
-	auto originalIter = db.machines().begin();
-	(void)originalIter;
-
-	// ensure that a deference of an offsetted default instantiated iterator throws an exception
-	decltype(originalIter) iter1;
-	decltype(originalIter) iter2 = iter1 + 42;
-	bool caughtOutOfRange = false;
-	try
-	{
-		(void)*iter2;
 	}
 	catch (const std::out_of_range &)
 	{

--- a/src/tests/info_test.cpp
+++ b/src/tests/info_test.cpp
@@ -33,6 +33,7 @@ namespace
 		void loadExpectedVersion_alienar()	{ loadExpectedVersion(":/resources/listxml_alienar.xml", "0.229 (mame0229)"); }
 		void badMachineLookup();
 		void viewIterators();
+		void viewIndexOutOfRange();
 		void loadGarbage_0_0()				{ loadGarbage(0, 0); }
 		void loadGarbage_0_1000()			{ loadGarbage(0, 1000); }
 		void loadGarbage_1000_0()			{ loadGarbage(1000, 0); }
@@ -274,6 +275,49 @@ void Test::viewIterators()
 	QVERIFY(!(iter1 != iter4));
 	QVERIFY(iter2 != iter4);
 	QVERIFY(iter3 != iter4);
+}
+
+
+//-------------------------------------------------
+//  viewIndexOutOfRange
+//-------------------------------------------------
+
+void Test::viewIndexOutOfRange()
+{
+	// load the db, validating we've done so successfully
+	info::database db;
+	QVERIFY(db.load(buildInfoDatabase()));
+	QVERIFY(db.machines().size() > 2);
+
+	// acceptable indexes
+	QVERIFY(!db.machines()[0].name().isEmpty());
+	QVERIFY(!db.machines()[1].name().isEmpty());
+	QVERIFY(!db.machines()[2].name().isEmpty());
+	QVERIFY(!db.machines()[db.machines().size() - 2].name().isEmpty());
+	QVERIFY(!db.machines()[db.machines().size() - 1].name().isEmpty());
+
+	// these indexes are out of range
+	size_t outOfRangeIndexes[] =
+	{
+		db.machines().size(),
+		db.machines().size() + 100,
+		0xDEADBEEF,
+		0xFFFFFFFF,
+		~((size_t)0)
+	};
+	for (size_t index : outOfRangeIndexes)
+	{
+		bool caughtOutOfRange = false;
+		try
+		{
+			(void)db.machines()[index];
+		}
+		catch (const std::out_of_range &)
+		{
+			caughtOutOfRange = true;
+		}
+		QVERIFY(caughtOutOfRange);
+	}
 }
 
 


### PR DESCRIPTION
Of course, iterator operations can bypass most of these, so info DB is still not perfectly "safe" (which is fine)