### PR TITLE
Optimized new implementation of info::database_builder::string_table

### DIFF
--- a/src/info_builder.cpp
+++ b/src/info_builder.cpp
@@ -733,8 +733,8 @@ std::uint32_t info::database_builder::string_table::get(std::u8string_view s)
 	// if we've already cached this value, look it up
 	auto iter = std::ranges::find_if(bucket, [this, &s](std::uint32_t thatId)
 	{
-		std::u8string_view thatString(&m_data[thatId]);
-		return s == thatString;
+		return (size_t)thatId + s.size() + 1 < m_data.capacity()
+			&& !memcmp(s.data(), &m_data[thatId], s.size());
 	});
 	if (iter != bucket.end())
 		return *iter;
@@ -749,7 +749,7 @@ std::uint32_t info::database_builder::string_table::get(std::u8string_view s)
 	m_data.insert(m_data.end(), '\0');
 
 	// and to the bucket
-	bucket.push_back(sizeBeforeAppend);
+	bucket.push_front(sizeBeforeAppend);
 
 	// and return
 	return sizeBeforeAppend;

--- a/src/info_builder.h
+++ b/src/info_builder.h
@@ -15,6 +15,9 @@
 #include "info.h"
 #include "xmlparser.h"
 
+// standard headers
+#include <forward_list>
+
 class QDataStream;
 
 namespace info
@@ -52,10 +55,10 @@ namespace info
 			template<typename T> void embed_value(T value);
 
 		private:
-			typedef std::vector<std::uint32_t> MapBucket;
+			typedef std::forward_list<std::uint32_t> MapBucket;
 
 			std::vector<char8_t>								m_data;
-			std::unique_ptr<std::array<MapBucket, 198503>>		m_mapBuckets;
+			std::unique_ptr<std::array<MapBucket, 318677>>		m_mapBuckets;
 		};
 
 		info::binaries::header									m_salted_header;


### PR DESCRIPTION
- Using std::forward_list instead of std::vector for buckets
- Using memcmp in comparison operation
- More buckets!