### PR TITLE
When invoking software from software lists, now specifying the full name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ To run BletchMAME, run the installer (BletchMAME.msi on Windows) and BletchMAME 
 	- Turning off the MAME intrinsic cassette animation as BletchMAME has its own UX (MAME 0.243 and later)
 	- Added an option to disable the warning displayed when stopping an emulation
 	- Added columns to the machine and software list views to identify source files
+	- When invoking software from software lists, now specifying the full name
+		- Failing to do so could cause problems when mulitple lists have the same name (e.g. - msx1_cart:hero vs msx1_cass:hero)
 	- Fixed a bug that could cause software lists with hex values (e.g. - size="0x2000") to not parse
 	- Fixed a bug that could cause crashes when parsing MAME -listxml output
 		- In practice this only happened with variant MAME builds with more machines than off the shelf MAME

--- a/src/sessionbehavior.cpp
+++ b/src/sessionbehavior.cpp
@@ -32,8 +32,9 @@ SessionBehavior::~SessionBehavior()
 //-------------------------------------------------
 
 NormalSessionBehavior::NormalSessionBehavior(const software_list::software *software)
-    : m_initialSoftware(software ? software->name() : "")
 {
+	if (software)
+		m_initialSoftware = QString("%1:%2").arg(software->parent().name(), software->name());
 }
 
 


### PR DESCRIPTION
Failing to do so could cause problems when mulitple lists have the same name (e.g. - msx1_cart:hero vs msx1_cass:hero)