### PR TITLE
Changes to XmlParser and associated cleanups

### DIFF
--- a/src/info_builder.cpp
+++ b/src/info_builder.cpp
@@ -504,7 +504,7 @@ bool info::database_builder::process_xml(QIODevice &input, QString &error_messag
 			current_device_extensions.append(u8",");
 		}
 	});
-	xml.onElementEnd({ "mame", "machine", "device" }, [this, &current_device_extensions](QString &&)
+	xml.onElementEnd({ "mame", "machine", "device" }, [this, &current_device_extensions]()
 	{
 		ProfilerScope prof(CURRENT_FUNCTION);
 		if (!current_device_extensions.empty())
@@ -561,11 +561,11 @@ bool info::database_builder::process_xml(QIODevice &input, QString &error_messag
 		ram_option.m_value						= 0;
 		util::last(m_machines).m_ram_options_count++;
 	});
-	xml.onElementEnd({ "mame", "machine", "ramoption" }, [this](QString &&content)
+	xml.onElementEnd({ "mame", "machine", "ramoption" }, [this](std::u8string &&content)
 	{
 		ProfilerScope prof(CURRENT_FUNCTION);
 		bool ok;
-		unsigned long val = content.toULong(&ok);
+		unsigned long val = util::toQString(content).toULong(&ok);
 		util::last(m_ram_options).m_value = ok ? val : 0;
 	});
 	xml.onElementBegin({ "mame", "machine", "sound" }, [this](const XmlParser::Attributes &attributes)

--- a/src/softwarelist.cpp
+++ b/src/softwarelist.cpp
@@ -35,21 +35,21 @@ bool software_list::load(QIODevice &stream, QString &error_message)
 		s.m_name		= attributes.get<QString>("name").value_or("");
 		s.m_parts.reserve(16);
 	});
-	xml.onElementEnd({ "softwarelist", "software" }, [this](QString &&)
+	xml.onElementEnd({ "softwarelist", "software" }, [this]()
 	{
 		util::last(m_software).m_parts.shrink_to_fit();
 	});
-	xml.onElementEnd({ "softwarelist", "software", "description" }, [this](QString &&content)
+	xml.onElementEnd({ "softwarelist", "software", "description" }, [this](std::u8string &&content)
 	{
-		util::last(m_software).m_description = std::move(content);
+		util::last(m_software).m_description = util::toQString(content);
 	});
-	xml.onElementEnd({ "softwarelist", "software", "year" }, [this](QString &&content)
+	xml.onElementEnd({ "softwarelist", "software", "year" }, [this](std::u8string &&content)
 	{
-		util::last(m_software).m_year = std::move(content);
+		util::last(m_software).m_year = util::toQString(content);
 	});
-	xml.onElementEnd({ "softwarelist", "software", "publisher" }, [this](QString &&content)
+	xml.onElementEnd({ "softwarelist", "software", "publisher" }, [this](std::u8string &&content)
 	{
-		util::last(m_software).m_publisher = std::move(content);
+		util::last(m_software).m_publisher = util::toQString(content);
 	});
 	xml.onElementBegin({ "softwarelist", "software", "part" }, [this](const XmlParser::Attributes &attributes)
 	{

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -168,11 +168,11 @@ status::update status::update::read(QIODevice &input_stream)
 		format.m_name						= attributes.get<QString>("name").value_or("");
 		format.m_description				= attributes.get<QString>("description").value_or("");
 	});
-	xml.onElementEnd({ "status", "images", "image", "details", "format", "extension" }, [&](QString &&content)
+	xml.onElementEnd({ "status", "images", "image", "details", "format", "extension" }, [&](std::u8string &&content)
 	{
 		image &image = util::last(*result.m_images);
 		image_format &format = util::last(image.m_details->m_formats);
-		format.m_extensions.push_back(std::move(content));
+		format.m_extensions.push_back(util::toQString(content));
 	});
 	xml.onElementBegin({ "status", "cassettes" }, [&](const XmlParser::Attributes &)
 	{
@@ -195,7 +195,7 @@ status::update status::update::read(QIODevice &input_stream)
 	{
 		result.m_slots.emplace();
 	});
-	xml.onElementEnd({ "status", "slots" }, [&](QString &&content)
+	xml.onElementEnd({ "status", "slots" }, [&]()
 	{
 		// downstream logic becomes much simpler if this is sorted
 		std::sort(

--- a/src/tests/xmlparser_test.cpp
+++ b/src/tests/xmlparser_test.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
 
     xmlparser_test.cpp
 
@@ -142,13 +142,13 @@ void XmlParser::Test::unicodeStdString()
 void XmlParser::Test::unicodeQString()
 {
 	XmlParser xml;
-	QString bravo_value;
+	std::u8string bravo_value;
 	std::optional<QString> charlie_value;
 	xml.onElementBegin({ "alpha", "bravo" }, [&](const XmlParser::Attributes &attributes)
 	{
 		charlie_value = attributes.get<QString>("charlie");
 	});
-	xml.onElementEnd({ "alpha", "bravo" }, [&](QString &&value)
+	xml.onElementEnd({ "alpha", "bravo" }, [&](std::u8string &&value)
 	{
 		bravo_value = std::move(value);
 	});
@@ -156,7 +156,7 @@ void XmlParser::Test::unicodeQString()
 	const char *xml_text = "<alpha><bravo charlie=\"&#x6B7B;\">&#x60AA;</bravo></alpha>";
 	bool result = xml.parseBytes(xml_text, strlen(xml_text));
 	QVERIFY(result);
-	QVERIFY(bravo_value.toStdWString() == L"\u60AA");
+	QVERIFY(bravo_value == u8"\u60AA");
 	QVERIFY(charlie_value);
 	QVERIFY(charlie_value->toStdWString() == L"\u6B7B");
 }

--- a/src/tests/xmlparser_test.cpp
+++ b/src/tests/xmlparser_test.cpp
@@ -21,6 +21,7 @@ private slots:
 	void unicodeQString();
 	void skipping();
 	void multiple();
+	void recursive();
 	void localeSensitivity();
 	void xmlParsingError();
 
@@ -223,6 +224,50 @@ void XmlParser::Test::multiple()
 	bool result = xml.parseBytes(xml_text, strlen(xml_text));
 	QVERIFY(result);
 	QVERIFY(total == 10);
+}
+
+
+//-------------------------------------------------
+//  recursive
+//-------------------------------------------------
+
+void XmlParser::Test::recursive()
+{
+	XmlParser xml;
+	int bravoTotal = 0;
+	int charlieTotal = 0;
+	xml.onElementBegin({ "alpha", "bravo", "..."}, [&](const XmlParser::Attributes &attributes)
+	{
+		int value = *attributes.get<int>("value");
+		bravoTotal += value;
+	});
+	xml.onElementBegin({ "alpha", "bravo", "charlie"}, [&](const XmlParser::Attributes &attributes)
+	{
+		int value = *attributes.get<int>("value");
+		charlieTotal += value;
+	});
+
+	const char *xml_text =
+		"<alpha>"
+		"\t<bravo value=\"2\">"
+		"\t\t<bravo value=\"3\">"
+		"\t\t\t<charlie value=\"5\"/>"
+		"\t\t\t<charlie value=\"8\">"
+		"\t\t\t\t<charlie value=\"8\"/>"
+		"\t\t\t\t<delta dummy=\"yeah\">"
+		"\t\t\t\t\t<charlie value=\"666\"/>"
+		"\t\t\t\t</delta>"
+		"\t\t\t</charlie>"
+		"\t\t</bravo>"
+		"\t\t<charlie value=\"13\"/>"
+		"\t\t<charlie value=\"21\"/>"
+		"\t</bravo>"
+		"\t<bravo value=\"34\"/>"
+		"</alpha>";
+	bool result = xml.parseBytes(xml_text, strlen(xml_text));
+	QVERIFY(result);
+	QVERIFY(bravoTotal == 39);
+	QVERIFY(charlieTotal == 47);
 }
 
 

--- a/src/utility.h
+++ b/src/utility.h
@@ -333,7 +333,7 @@ TStr string_join(const TStr &delim, const TColl &collection, TFunc func)
 	TStr result;
 	bool is_first = true;
 
-	for (const TStr &member : collection)
+	for (const auto &member : collection)
 	{
 		if (is_first)
 			is_first = false;

--- a/src/xmlparser.cpp
+++ b/src/xmlparser.cpp
@@ -420,10 +420,61 @@ bool XmlParser::isWhitespace(char ch) noexcept
 
 
 //-------------------------------------------------
+//  onElementEnd (const char *)
+//-------------------------------------------------
+
+void XmlParser::onElementEnd(const std::initializer_list<const char *> &elements, OnEndElementCallback &&func) noexcept
+{
+	getNode(elements).m_endFunc = std::move(func);
+}
+
+
+//-------------------------------------------------
+//  onElementEnd (multiple const char *)
+//-------------------------------------------------
+
+void XmlParser::onElementEnd(const std::initializer_list<const std::initializer_list<const char *>> &elements, OnEndElementCallback &&func) noexcept
+{
+	for (auto iter = elements.begin(); iter != elements.end(); iter++)
+	{
+		OnEndElementCallback func_duplicate(func);
+		onElementEnd(*iter, std::move(func_duplicate));
+	}
+}
+
+
+//-------------------------------------------------
+//  onElementEnd (void)
+//-------------------------------------------------
+
+void XmlParser::onElementEnd(const std::initializer_list<const char *> &elements, OnEndElementVoidCallback &&func) noexcept
+{
+	getNode(elements).m_endFunc = [func{ std::move(func) }](std::u8string &&)
+	{
+		func();
+	};
+}
+
+
+//-------------------------------------------------
+//  onElementEnd (multiple void)
+//-------------------------------------------------
+
+void XmlParser::onElementEnd(const std::initializer_list<const std::initializer_list<const char *>> &elements, OnEndElementVoidCallback &&func) noexcept
+{
+	for (auto iter = elements.begin(); iter != elements.end(); iter++)
+	{
+		OnEndElementVoidCallback func_duplicate(func);
+		onElementEnd(*iter, std::move(func_duplicate));
+	}
+}
+
+
+//-------------------------------------------------
 //  getNode
 //-------------------------------------------------
 
-XmlParser::Node *XmlParser::getNode(const std::initializer_list<const char *> &elements) noexcept
+XmlParser::Node &XmlParser::getNode(const std::initializer_list<const char *> &elements) noexcept
 {
 	Node *node = m_root.get();
 
@@ -437,7 +488,7 @@ XmlParser::Node *XmlParser::getNode(const std::initializer_list<const char *> &e
 
 		node = child.get();
 	}
-	return node;
+	return *node;
 }
 
 

--- a/src/xmlparser.cpp
+++ b/src/xmlparser.cpp
@@ -164,8 +164,7 @@ static const util::enum_parser<bool> s_bool_parser =
 //-------------------------------------------------
 
 XmlParser::XmlParser()
-	: m_root(std::make_unique<Node>(nullptr))
-	, m_skippingDepth(0)
+	: m_root(std::make_unique<Node>())
 {
 	m_parser = XML_ParserCreate(nullptr);
 
@@ -191,13 +190,16 @@ XmlParser::~XmlParser()
 
 bool XmlParser::parse(QIODevice &input) noexcept
 {
-	m_currentNode = m_root.get();
-	m_skippingDepth = 0;
+	// push the initial node onto the stack
+	assert(m_currentNodeStack.empty());
+	m_currentNodeStack.push(m_root.get());
 
+	// parse all the things!
 	bool success = internalParse(input);
 
-	m_currentNode = nullptr;
-	m_skippingDepth = 0;
+	// clear out the node stack and return
+	assert(!success || m_currentNodeStack.size() == 1);
+	m_currentNodeStack = decltype(m_currentNodeStack)();
 	return success;
 }
 
@@ -480,13 +482,22 @@ XmlParser::Node &XmlParser::getNode(const std::initializer_list<const char *> &e
 
 	for (auto iter = elements.begin(); iter != elements.end(); iter++)
 	{
-		Node::ptr &child(node->m_map[*iter]);
+		// special case
+		bool isElipsis = !strcmp(*iter, "...");
 
-		// create the child node if it is not present
-		if (!child)
-			child = std::make_unique<Node>(node);
+		// find out the element name used to walk
+		const char *elementName = iter[isElipsis ? -1 : 0];
 
-		node = child.get();
+		Node::ptr &child(node->m_map[elementName]);
+
+		if (!isElipsis)
+		{
+			// create the child node if it is not present
+			if (!child)
+				child = std::make_unique<Node>();
+
+			node = child.get();
+		}
 	}
 	return *node;
 }
@@ -501,59 +512,46 @@ void XmlParser::startElement(const char *element, const char **attributes) noexc
 	ProfilerScope prof(CURRENT_FUNCTION);
 
 	// only try to find this node in our tables if we are not skipping
-	Node *child = nullptr;
-	if (m_skippingDepth == 0)
+	const Node *currentNode = m_currentNodeStack.top();
+	const Node *childNode;
+	if (currentNode)
 	{
-		auto iter = m_currentNode->m_map.find(element);
-		if (iter != m_currentNode->m_map.end())
-			child = iter->second.get();
-	}
-
-	// figure out how to handle this element
-	ElementResult result;
-	if (child)
-	{
-		// we do - traverse down the tree
-		m_currentNode = child;
-
-		// do we have a callback function for beginning this node?
-		if (m_currentNode->m_beginFunc)
+		// we're in a node - find the child element
+		auto iter = currentNode->m_map.find(element);
+		if (iter != currentNode->m_map.end())
 		{
-			// we do - call it
-			Attributes attributesObject(*this, attributes);
-			result = m_currentNode->m_beginFunc(attributesObject);
+			// we've found the child (which could be the current node if we're recursing)
+			childNode = iter->second ? iter->second.get() : currentNode;
 		}
 		else
 		{
-			// we don't; we treat this as a normal node
-			result = ElementResult::Ok;
+			// this child is unknown - we have to ignore it
+			childNode = nullptr;
 		}
 	}
 	else
 	{
-		// we don't - we start skipping
-		result = ElementResult::Skip;
+		// we're currently in an unknown node and we're ignoring it - so we need to ignore the child too
+		childNode = nullptr;
 	}
 
-	// do the dirty work
-	switch (result)
+	// do we have a callback function for beginning this node?
+	if (childNode && childNode->m_beginFunc)
 	{
-	case ElementResult::Ok:
-		// do nothing
-		break;
+		// we do - call it
+		Attributes attributesObject(*this, attributes);
+		ElementResult result = childNode->m_beginFunc(attributesObject);
 
-	case ElementResult::Skip:
-		// we're skipping this element; treat it the same as an unknown element
-		m_skippingDepth++;
-		break;
-
-	default:
-		assert(false);
-		break;
+		// were we instructed to skip?
+		if (result == ElementResult::Skip)
+			childNode = nullptr;
 	}
+
+	// and push this onto the stack
+	m_currentNodeStack.push(childNode);
 
 	// set up content, but only if we expect to emit it later
-	if (m_skippingDepth == 0 && m_currentNode->m_endFunc)
+	if (childNode && childNode->m_endFunc)
 	{
 		m_currentContent.emplace();
 		m_currentContent->reserve(1024);
@@ -573,23 +571,16 @@ void XmlParser::endElement(const char *) noexcept
 {
 	ProfilerScope prof(CURRENT_FUNCTION);
 
-	if (m_skippingDepth)
+	// call back the end func, if appropriate
+	const Node *currentNode = m_currentNodeStack.top();
+	if (currentNode && currentNode->m_endFunc)
 	{
-		// coming out of an unknown element type
-		m_skippingDepth--;
+		currentNode->m_endFunc(m_currentContent ? std::move(*m_currentContent) : std::u8string());
+		m_currentContent.reset();
 	}
-	else
-	{
-		// call back the end func, if appropriate
-		if (m_currentNode->m_endFunc)
-		{
-			m_currentNode->m_endFunc(m_currentContent ? std::move(*m_currentContent) : std::u8string());
-			m_currentContent.reset();
-		}
 
-		// and go up the tree
-		m_currentNode = m_currentNode->m_parent;
-	}
+	// and go up the tree
+	m_currentNodeStack.pop();
 }
 
 
@@ -821,24 +812,4 @@ void XmlParser::Attributes::reportAttributeParsingError(const char *attribute, s
 		QString(attribute),
 		util::toQString(value));
 	m_parser.appendError(std::move(message));
-}
-
-
-//-------------------------------------------------
-//  Node ctor
-//-------------------------------------------------
-
-XmlParser::Node::Node(Node *parent)
-	: m_parent(parent)
-{
-
-}
-
-
-//-------------------------------------------------
-//  Node dtor
-//-------------------------------------------------
-
-XmlParser::Node::~Node()
-{
 }

--- a/src/xmlparser.h
+++ b/src/xmlparser.h
@@ -11,14 +11,17 @@
 #ifndef XMLPARSER_H
 #define XMLPARSER_H
 
-#include <initializer_list>
-#include <memory>
-#include <type_traits>
-#include <optional>
+// bletchmame headers
+#include "utility.h"
 
+// Qt headers
 #include <QIODevice>
 
-#include "utility.h"
+// standard headers
+#include <initializer_list>
+#include <memory>
+#include <optional>
+#include <type_traits>
 
 struct XML_ParserStruct;
 

--- a/src/xmlparser.h
+++ b/src/xmlparser.h
@@ -21,6 +21,7 @@
 #include <initializer_list>
 #include <memory>
 #include <optional>
+#include <stack>
 #include <type_traits>
 
 struct XML_ParserStruct;
@@ -155,22 +156,22 @@ private:
 		typedef std::unordered_map<const char *, Node::ptr> Map;
 
 		// ctor/dtor
-		Node(Node *parent);
+		Node() = default;
 		Node(const Node &) = delete;
 		Node(Node &&) = delete;
-		~Node();
+		~Node() = default;
 
 		// fields
 		OnBeginElementCallback		m_beginFunc;
 		OnEndElementCallback		m_endFunc;
-		Node *						m_parent;
 		Map							m_map;
 	};
 
+	typedef std::stack<const Node *> NodeStack;
+
 	struct XML_ParserStruct *		m_parser;
 	Node::ptr						m_root;
-	Node *							m_currentNode;
-	int								m_skippingDepth;
+	NodeStack						m_currentNodeStack;
 	std::optional<std::u8string>	m_currentContent;
 	std::vector<Error>				m_errors;
 

--- a/src/xmlparser.h
+++ b/src/xmlparser.h
@@ -119,7 +119,7 @@ public:
 		auto proxy = proxy_type(std::move(func));
 
 		// supply the proxy
-		getNode(elements)->m_beginFunc = std::move(proxy);
+		getNode(elements).m_beginFunc = std::move(proxy);
 	}
 
 	// onElementBegin
@@ -135,36 +135,13 @@ public:
 
 	// onElementEnd (std::u8string)
 	typedef std::function<void(std::u8string &&content)> OnEndElementCallback;
-	void onElementEnd(const std::initializer_list<const char *> &elements, OnEndElementCallback &&func) noexcept
-	{
-		getNode(elements)->m_endFunc = std::move(func);
-	}
-	void onElementEnd(const std::initializer_list<const std::initializer_list<const char *>> &elements, OnEndElementCallback &&func) noexcept
-	{
-		for (auto iter = elements.begin(); iter != elements.end(); iter++)
-		{
-			OnEndElementCallback func_duplicate(func);
-			onElementEnd(*iter, std::move(func_duplicate));
-		}
-	}
+	void onElementEnd(const std::initializer_list<const char *> &elements, OnEndElementCallback &&func) noexcept;
+	void onElementEnd(const std::initializer_list<const std::initializer_list<const char *>> &elements, OnEndElementCallback &&func) noexcept;
 
-	// onElementEnd (QString)
-	typedef std::function<void(QString &&content)> OnEndElementQStringCallback;
-	void onElementEnd(const std::initializer_list<const char *> &elements, OnEndElementQStringCallback &&func) noexcept
-	{
-		getNode(elements)->m_endFunc = [func{std::move(func)}](std::u8string &&content)
-		{
-			func(util::toQString(content));
-		};
-	}
-	void onElementEnd(const std::initializer_list<const std::initializer_list<const char *>> &elements, OnEndElementQStringCallback &&func) noexcept
-	{
-		for (auto iter = elements.begin(); iter != elements.end(); iter++)
-		{
-			OnEndElementQStringCallback func_duplicate(func);
-			onElementEnd(*iter, std::move(func_duplicate));
-		}
-	}
+	// onElementEnd (void)
+	typedef std::function<void()> OnEndElementVoidCallback;
+	void onElementEnd(const std::initializer_list<const char *> &elements, OnEndElementVoidCallback &&func) noexcept;
+	void onElementEnd(const std::initializer_list<const std::initializer_list<const char *>> &elements, OnEndElementVoidCallback &&func) noexcept;
 
 	bool parse(QIODevice &input) noexcept;
 	bool parse(const QString &file_name) noexcept;
@@ -208,7 +185,7 @@ private:
 	static QString errorContext(const char *contextString, int contextOffset, int contextSize) noexcept;
 	static bool isLineEnding(char ch) noexcept;
 	static bool isWhitespace(char ch) noexcept;
-	Node *getNode(const std::initializer_list<const char *> &elements) noexcept;
+	Node &getNode(const std::initializer_list<const char *> &elements) noexcept;
 
 	static void startElementHandler(void *user_data, const char *name, const char **attributes);
 	static void endElementHandler(void *user_data, const char *name);


### PR DESCRIPTION
- Added support for recursive elements to `XmlParser` (not used yet)
- `onElementEnd()` no longer has an overload taking `QString`, but has one taking no parameters
- `onElementBegin()` and `onElementEnd()` have been moved out of the header to xmlparser.cpp
- Other miscellaneous cleanups